### PR TITLE
refactor: rename package and update homepage

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,4 +1,4 @@
-Source: linglong-store
+Source: linyaps-web-store-installer
 Section: admin
 Priority: optional
 Maintainer: Deepin Packages Builder <packages@deepin.org>
@@ -9,7 +9,7 @@ Build-Depends:
  qt6-base-dev | qtbase5-dev,
  xdg-utils
 Standards-Version: 4.1.3
-Homepage: https://www.deepin.org
+Homepage: https://linyaps.org.cn
 
 Package: linglong-installer
 Architecture: any


### PR DESCRIPTION
1. Renamed the source package from `linglong-store` to `linyaps-web- store-installer`. This change reflects a shift in branding or project ownership, ensuring the package name accurately represents the current state of the software.
2. Updated the `Homepage` field to point to `https://linyaps.org.cn`. This ensures users and developers are directed to the correct and current project website for information, documentation, and support.

Influence:
1. Verify that the package can be built and installed with the new name.
2. Ensure the new homepage URL is accessible and contains relevant information about the project.
3. Check any dependencies or references to the old package name are updated accordingly.

refactor: 重命名软件包并更新主页

1. 将源软件包名称从 `linglong-store` 重命名为 `linyaps-web-store- installer`。 此更改反映了品牌或项目所有权的转变，确保软件包名称准确代表
软件的当前状态。
2. 更新 `Homepage` 字段以指向 `https://linyaps.org.cn`。 这确保用户和开 发人员被引导到正确且最新的项目网站，以获取信息、文档和支持。

Influence:
1. 验证是否可以使用新名称构建和安装软件包。
2. 确保新的主页 URL 可访问并且包含有关项目的相关信息。
3. 检查对旧软件包名称的任何依赖项或引用是否已相应更新。