### PR TITLE
chore: refine desktop entry for ll-installer

### DIFF
--- a/ll-installer/space.linglong.Installer.desktop
+++ b/ll-installer/space.linglong.Installer.desktop
@@ -4,8 +4,7 @@
 Encoding=UTF-8
 Type=Application
 X-Created-By=Linglong
-Categories=chat;
-Icon=
+Icon=linyaps
 Exec=/usr/bin/ll-installer -u %u
 NoDisplay=true
 Name=Linglong Store Installer


### PR DESCRIPTION
This commit refines the desktop entry file for ll-installer. The "Categories" entry was removed as it was irrelevant, and the "Icon" entry was updated to "linyaps" to use a more appropriate icon. The MimeType line was preserved.

Influence:
1. Verify the ll-installer desktop entry displays correctly in application launchers.
2. Ensure the icon is displayed correctly in file managers and launchers.
3. Confirm that ll-installer is launched when an og scheme is triggered.