### PR TITLE
chore: rename package in changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-linglong-store (1.6.7-1) unstable; urgency=medium
+linyaps-web-store-installer (1.6.7-1) unstable; urgency=medium
 
   * release 1.6.7-1.
 


### PR DESCRIPTION
This commit renames the package name from "linglong-store" to "linyaps- web-store-installer" in the debian/changelog file. This change is necessary to reflect the new official package name for the store installer, ensuring consistency and correct identification of the package within the Debian packaging system. The previous name was outdated and no longer accurate.

Influence:
1. Verify that the package name in debian/changelog is correctly updated to "linyaps-web-store-installer".
2. Confirm that the Debian packaging process uses the updated name during build and distribution.