### PR TITLE
chore: Bump minimum required CMake to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 project(linglong-store)
 


### PR DESCRIPTION
Since CMake 4, `cmake_minimum_required` with versions lower than 3.5 will throw error, also `cmake_minimum_required` with versions lower than 3.10 is also deprecated too, so bumping to 3.10.