### PR TITLE
chore(packaging): add xdg-utils runtime dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,6 +12,6 @@ Homepage: https://linyaps.org.cn
 
 Package: linglong-installer
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, linglong-bin
+Depends: ${shlibs:Depends}, ${misc:Depends}, linglong-bin, xdg-utils
 Description: Deepin sandbox with OCI standard.
   Deepin sandbox...


### PR DESCRIPTION
Add xdg-utils to Depends so the installer can open URLs via xdg-open in a desktop environment.